### PR TITLE
Handling Fahrenheit devices

### DIFF
--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -229,7 +229,7 @@ void AirConditioner::ParseResponse()
     bool need_publish = false;
     
     if(this->reports_fahrenheit_) {
-      update_property(this->current_temperature, F2C(RXData[RX_BYTE_T1_TEMP]), need_publish);
+      update_property(this->current_temperature, F2C((float)RXData[RX_BYTE_T1_TEMP]), need_publish);
     } else {
       update_property(this->current_temperature, (float)CalculateTemp(RXData[RX_BYTE_T1_TEMP]), need_publish);
     }
@@ -242,7 +242,7 @@ void AirConditioner::ParseResponse()
     if( mode != ClimateMode::CLIMATE_MODE_OFF || ForceReadNextCycle == 1) //Don't update below states unless mode is an ON state
     {
       if(this->reports_fahrenheit_) {
-        update_property(this->target_temperature, F2C(RXData[RX_BYTE_SET_TEMP], need_publish);
+        update_property(this->target_temperature, F2C((float)RXData[RX_BYTE_SET_TEMP], need_publish);
       } else {
         update_property(this->target_temperature, (float)RXData[RX_BYTE_SET_TEMP], need_publish);
       }
@@ -266,9 +266,9 @@ void AirConditioner::ParseResponse()
       this->publish_state();
 
     if(this->reports_fahrenheit_) {
-      set_sensor(this->outdoor_sensor_, F2C(RXData[RX_BYTE_T3_TEMP]) );
-      set_sensor(this->temperature_2a_sensor_, F2C(RXData[RX_BYTE_T2A_TEMP]));
-      set_sensor(this->temperature_2b_sensor_, F2C(RXData[RX_BYTE_T2B_TEMP]));
+      set_sensor(this->outdoor_sensor_, F2C((float)RXData[RX_BYTE_T3_TEMP]) );
+      set_sensor(this->temperature_2a_sensor_, F2C((float)RXData[RX_BYTE_T2A_TEMP]));
+      set_sensor(this->temperature_2b_sensor_, F2C((float)RXData[RX_BYTE_T2B_TEMP]));
     } else {
       set_sensor(this->outdoor_sensor_, CalculateTemp(RXData[RX_BYTE_T3_TEMP]) );
       set_sensor(this->temperature_2a_sensor_, CalculateTemp(RXData[RX_BYTE_T2A_TEMP]));
@@ -374,12 +374,12 @@ float AirConditioner::CalculateTemp(uint8_t byte) {
 
 float AirConditioner::C2F(float in)
 {
-  return in*1.8 + 32;
+  return in*1.8 + 32.0;
 }
 
 float AirConditioner::F2C(float in)
 {
-  return (f-32)/1.8;
+  return (in-32.0)/1.8;
 }
 
 ClimateTraits AirConditioner::traits() {

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -123,7 +123,7 @@ void AirConditioner::update() {
       }
       //set temp 
       if(this->reports_fahrenheit_) {
-        TXData[8] = C2F(this->target_temperature);
+        TXData[8] = (uint8_t)C2F(this->target_temperature);
       }
       else {
         TXData[8] =  this->target_temperature;
@@ -242,7 +242,7 @@ void AirConditioner::ParseResponse()
     if( mode != ClimateMode::CLIMATE_MODE_OFF || ForceReadNextCycle == 1) //Don't update below states unless mode is an ON state
     {
       if(this->reports_fahrenheit_) {
-        update_property(this->target_temperature, F2C((float)RXData[RX_BYTE_SET_TEMP], need_publish);
+        update_property(this->target_temperature, F2C((float)RXData[RX_BYTE_SET_TEMP]), need_publish);
       } else {
         update_property(this->target_temperature, (float)RXData[RX_BYTE_SET_TEMP], need_publish);
       }

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -229,7 +229,7 @@ void AirConditioner::ParseResponse()
     bool need_publish = false;
     
     if(this->reports_fahrenheit_) {
-      update_property(this->current_temperature, F2C(RXData[RX_BYTE_T1_TEMP]), need_publish);
+      update_property(this->current_temperature, F2C((float)RXData[RX_BYTE_T1_TEMP]), need_publish);
     } else {
       update_property(this->current_temperature, (float)CalculateTemp(RXData[RX_BYTE_T1_TEMP]), need_publish);
     }
@@ -242,7 +242,7 @@ void AirConditioner::ParseResponse()
     if( mode != ClimateMode::CLIMATE_MODE_OFF || ForceReadNextCycle == 1) //Don't update below states unless mode is an ON state
     {
       if(this->reports_fahrenheit_) {
-        update_property(this->target_temperature, F2C(RXData[RX_BYTE_SET_TEMP], need_publish);
+        update_property(this->target_temperature, F2C((float)RXData[RX_BYTE_SET_TEMP], need_publish);
       } else {
         update_property(this->target_temperature, (float)RXData[RX_BYTE_SET_TEMP], need_publish);
       }
@@ -266,9 +266,9 @@ void AirConditioner::ParseResponse()
       this->publish_state();
 
     if(this->reports_fahrenheit_) {
-      set_sensor(this->outdoor_sensor_, F2C(RXData[RX_BYTE_T3_TEMP]) );
-      set_sensor(this->temperature_2a_sensor_, F2C(RXData[RX_BYTE_T2A_TEMP]));
-      set_sensor(this->temperature_2b_sensor_, F2C(RXData[RX_BYTE_T2B_TEMP]));
+      set_sensor(this->outdoor_sensor_, F2C((float)RXData[RX_BYTE_T3_TEMP]) );
+      set_sensor(this->temperature_2a_sensor_, F2C((float)RXData[RX_BYTE_T2A_TEMP]));
+      set_sensor(this->temperature_2b_sensor_, F2C((float)RXData[RX_BYTE_T2B_TEMP]));
     } else {
       set_sensor(this->outdoor_sensor_, CalculateTemp(RXData[RX_BYTE_T3_TEMP]) );
       set_sensor(this->temperature_2a_sensor_, CalculateTemp(RXData[RX_BYTE_T2A_TEMP]));
@@ -374,12 +374,12 @@ float AirConditioner::CalculateTemp(uint8_t byte) {
 
 float AirConditioner::C2F(float in)
 {
-  return in*1.8 + 32;
+  return in*1.8 + 32.0;
 }
 
 float AirConditioner::F2C(float in)
 {
-  return (f-32)/1.8;
+  return (f-32.0)/1.8;
 }
 
 ClimateTraits AirConditioner::traits() {

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -123,7 +123,9 @@ void AirConditioner::update() {
       }
       //set temp 
       if(this->reports_fahrenheit_) {
+        ESP_LOGE(Constants::TAG,"Target Temp: %f", this->target_temperature);
         TXData[8] = (uint8_t)round(C2F(this->target_temperature));
+        ESP_LOGE(Constants::TAG,"TXData[8]: %d", TXData[8]);
       }
       else {
         TXData[8] =  this->target_temperature;

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -93,7 +93,7 @@ void AirConditioner::update() {
     if(0==UpdateNextCycle)
     {
       //construct query command
-//      setClientCommand(CLIENT_COMMAND_QUERY);
+      setClientCommand(CLIENT_COMMAND_QUERY);
 
     }else
     {
@@ -147,14 +147,14 @@ void AirConditioner::update() {
       UpdateNextCycle=0;
     }  
 
-if(0!=UpdateNextCycle){
+//if(0!=UpdateNextCycle){
     //TODO: Reimplement flow control for manual RS485 flow control chips 
     //digitalWrite(ComControlPin, RS485_TX_PIN_VALUE);
     this->uart_->write_array(TXData, TX_LEN);
     this->uart_->flush();
     delay(this->response_timeout);
     //digitalWrite(ComControlPin, RS485_RX_PIN_VALUE);
-}
+//}
     uint8_t i = 0;
     while (this->uart_->available())
     {

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -349,7 +349,8 @@ uint32_t AirConditioner::CalculateGetTime(uint8_t time)
 }
 
 float AirConditioner::CalculateTemp(uint8_t byte) {
-  return (byte-0x30)/2.0;
+  //return (byte-0x30)/2.0;
+  return byte;
 }
 
 ClimateTraits AirConditioner::traits() {

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -49,7 +49,7 @@ void AirConditioner::setup() {
   this->fan_mode = ClimateFanMode::CLIMATE_FAN_AUTO;
 
   //Set interface to Celcius
-  setClientCommand(CLIENT_COMMAND_CELCIUS);
+  //setClientCommand(CLIENT_COMMAND_CELCIUS);
   this->uart_->write_array(TXData, TX_LEN);
   this->uart_->flush();
   delay(this->response_timeout);

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -27,7 +27,7 @@ void AirConditioner::control(const ClimateCall &call) {
   if (call.get_mode().has_value())
     this->mode = call.get_mode().value();  
   if (call.get_target_temperature().has_value())
-    this->target_temperature = (int) call.get_target_temperature().value();
+    this->target_temperature = call.get_target_temperature().value();
   if (call.get_fan_mode().has_value())
     this->fan_mode = call.get_fan_mode().value();
   if (call.get_swing_mode().has_value())

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -123,7 +123,7 @@ void AirConditioner::update() {
       }
       //set temp 
       if(this->reports_fahrenheit_) {
-        TXData[8] = (uint8_t)C2F(this->target_temperature);
+        TXData[8] = (uint8_t)round(C2F(this->target_temperature));
       }
       else {
         TXData[8] =  this->target_temperature;

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -49,14 +49,15 @@ void AirConditioner::setup() {
   this->fan_mode = ClimateFanMode::CLIMATE_FAN_AUTO;
 
   //Set interface to Celcius
-  //setClientCommand(CLIENT_COMMAND_CELCIUS);
-  this->uart_->write_array(TXData, TX_LEN);
-  this->uart_->flush();
-  delay(this->response_timeout);
-  uint8_t data;
-  while (this->uart_->available())
-    this->uart_->read_byte(&data);
-
+  if(!this->reports_fahrenheit_) {
+    //setClientCommand(CLIENT_COMMAND_CELCIUS);
+    this->uart_->write_array(TXData, TX_LEN);
+    this->uart_->flush();
+    delay(this->response_timeout);
+    uint8_t data;
+    while (this->uart_->available())
+      this->uart_->read_byte(&data);
+  }
 }
 
 //TODO: Not sure if we really need this.

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -93,7 +93,7 @@ void AirConditioner::update() {
     if(0==UpdateNextCycle)
     {
       //construct query command
-      setClientCommand(CLIENT_COMMAND_QUERY);
+//      setClientCommand(CLIENT_COMMAND_QUERY);
 
     }else
     {
@@ -147,14 +147,14 @@ void AirConditioner::update() {
       UpdateNextCycle=0;
     }  
 
-
+if(0!=UpdateNextCycle){
     //TODO: Reimplement flow control for manual RS485 flow control chips 
     //digitalWrite(ComControlPin, RS485_TX_PIN_VALUE);
     this->uart_->write_array(TXData, TX_LEN);
     this->uart_->flush();
     delay(this->response_timeout);
     //digitalWrite(ComControlPin, RS485_RX_PIN_VALUE);
-
+}
     uint8_t i = 0;
     while (this->uart_->available())
     {

--- a/esphome/components/midea_xye/air_conditioner.cpp
+++ b/esphome/components/midea_xye/air_conditioner.cpp
@@ -50,7 +50,7 @@ void AirConditioner::setup() {
 
   //Set interface to Celcius
   if(!this->reports_fahrenheit_) {
-    //setClientCommand(CLIENT_COMMAND_CELCIUS);
+    setClientCommand(CLIENT_COMMAND_CELCIUS);
     this->uart_->write_array(TXData, TX_LEN);
     this->uart_->flush();
     delay(this->response_timeout);
@@ -124,9 +124,7 @@ void AirConditioner::update() {
       }
       //set temp 
       if(this->reports_fahrenheit_) {
-        ESP_LOGE(Constants::TAG,"Target Temp: %f", this->target_temperature);
         TXData[8] = (uint8_t)round(C2F(this->target_temperature));
-        ESP_LOGE(Constants::TAG,"TXData[8]: %d", TXData[8]);
       }
       else {
         TXData[8] =  this->target_temperature;

--- a/esphome/components/midea_xye/air_conditioner.h
+++ b/esphome/components/midea_xye/air_conditioner.h
@@ -191,6 +191,7 @@ public:
   void set_supported_presets(const std::set<ClimatePreset> &presets) { this->supported_presets_ = presets; }
   void set_custom_presets(const std::set<std::string> &presets) { this->supported_custom_presets_ = presets; }
   void set_custom_fan_modes(const std::set<std::string> &modes) { this->supported_custom_fan_modes_ = modes; }
+  void set_reports_fahrenheit() { this->reports_fahrenheit_ = true; }
 
   uint8_t TXData[TX_LEN];
   uint8_t RXData[RX_LEN];
@@ -229,6 +230,9 @@ protected:
   uint8_t CalculateSetTime(uint32_t time);
   uint32_t CalculateGetTime(uint8_t time);
   static float CalculateTemp(uint8_t byte);
+  static float F2C(float in);
+  static float C2C(float in);
+  bool reports_fahrenheit_{false};
 };
 
 }  // namespace ac

--- a/esphome/components/midea_xye/air_conditioner.h
+++ b/esphome/components/midea_xye/air_conditioner.h
@@ -231,7 +231,7 @@ protected:
   uint32_t CalculateGetTime(uint8_t time);
   static float CalculateTemp(uint8_t byte);
   static float F2C(float in);
-  static float C2C(float in);
+  static float C2F(float in);
   bool reports_fahrenheit_{false};
 };
 

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -142,21 +142,21 @@ CONFIG_SCHEMA = cv.All(
                 validate_custom_fan_modes
             ),
             cv.Optional(CONF_OUTDOOR_TEMPERATURE): sensor.sensor_schema(
-                unit_of_measurement=UNIT_FAHRENHEIT,
+                unit_of_measurement=UNIT_CELSIUS,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_TEMPERATURE_2A): sensor.sensor_schema(
-                unit_of_measurement=UNIT_FAHRENHEIT,
+                unit_of_measurement=UNIT_CELSIUS,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_TEMPERATURE_2B): sensor.sensor_schema(
-                unit_of_measurement=UNIT_FAHRENHEIT,
+                unit_of_measurement=UNIT_CELSIUS,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -34,7 +34,6 @@ from esphome.const import (
     UNIT_AMPERE,
     UNIT_MINUTE,
     UNIT_EMPTY,
-    UNIT_FAHRENHEIT,
 )
 from esphome.components.climate import (
     ClimateMode,

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -34,6 +34,7 @@ from esphome.const import (
     UNIT_AMPERE,
     UNIT_MINUTE,
     UNIT_EMPTY,
+    UNIT_FAHRENHEIT,
 )
 from esphome.components.climate import (
     ClimateMode,
@@ -141,21 +142,21 @@ CONFIG_SCHEMA = cv.All(
                 validate_custom_fan_modes
             ),
             cv.Optional(CONF_OUTDOOR_TEMPERATURE): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
+                unit_of_measurement=UNIT_FAHRENHEIT,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_TEMPERATURE_2A): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
+                unit_of_measurement=UNIT_FAHRENHEIT,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_TEMPERATURE_2B): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
+                unit_of_measurement=UNIT_FAHRENHEIT,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,

--- a/esphome/components/midea_xye/climate.py
+++ b/esphome/components/midea_xye/climate.py
@@ -55,6 +55,7 @@ CONF_ERROR_FLAGS = "error_flags"
 CONF_PROTECT_FLAGS = "protect_flags"
 CONF_POWER_USAGE = "power_usage"
 CONF_HUMIDITY_SETPOINT = "humidity_setpoint"
+CONF_REPORTS_FAHRENHEIT = "reports_fahrenheit"
 midea_ac_ns = cg.esphome_ns.namespace("midea").namespace("ac")
 AirConditioner = midea_ac_ns.class_("AirConditioner", climate.Climate, cg.Component)
 Capabilities = midea_ac_ns.namespace("Constants")
@@ -212,6 +213,7 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_REPORTS_FAHRENHEIT, default=False): cv.boolean,
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -375,4 +377,6 @@ async def to_code(config):
     if CONF_HUMIDITY_SETPOINT in config:
         sens = await sensor.new_sensor(config[CONF_HUMIDITY_SETPOINT])
         cg.add(var.set_humidity_setpoint_sensor(sens))
+    if config[CONF_REPORTS_FAHRENHEIT]:
+        cg.add(var.set_reports_fahrenheit())
     #cg.add_library("dudanov/MideaUART", "1.1.8")


### PR DESCRIPTION
# What does this implement/fix?

Original code and reverse engineering only considers non US devices.

However, US devices report raw values in Fahrenheit directly and the temperature conversions do not apply.

This PR adds a `reports_fahrenheit` boolean (default: false). If false, no changes. If true, conversion to/from Fahrenheit happen.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
