### PR TITLE
[feedback] add valve platform

### DIFF
--- a/esphome/components/feedback/valve/__init__.py
+++ b/esphome/components/feedback/valve/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+from esphome.components import valve
+import esphome.config_validation as cv
+
+from .. import (
+    FEEDBACK_ACTUATOR_SCHEMA,
+    FEEDBACK_ACTUATOR_VALIDATORS,
+    FeedbackActuatorBase,
+    apply_feedback_actuator_config,
+    feedback_ns,
+)
+
+# Auto-load the parent feedback component so its source files
+# (feedback_actuator.cpp/.h) are picked up by the build.
+AUTO_LOAD = ["feedback"]
+
+FeedbackValve = feedback_ns.class_("FeedbackValve", FeedbackActuatorBase, valve.Valve)
+
+CONFIG_SCHEMA = cv.All(
+    valve.valve_schema(FeedbackValve)
+    .extend(FEEDBACK_ACTUATOR_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
+    *FEEDBACK_ACTUATOR_VALIDATORS,
+)
+
+
+async def to_code(config):
+    var = await valve.new_valve(config)
+    await cg.register_component(var, config)
+    await apply_feedback_actuator_config(var, config)

--- a/esphome/components/feedback/valve/feedback_valve.cpp
+++ b/esphome/components/feedback/valve/feedback_valve.cpp
@@ -1,0 +1,56 @@
+#include "feedback_valve.h"
+#include "esphome/core/log.h"
+
+namespace esphome::feedback {
+
+static const char *const TAG = "feedback.valve";
+
+using namespace esphome::valve;
+
+ValveTraits FeedbackValve::get_traits() {
+  auto traits = ValveTraits();
+  traits.set_supports_stop(true);
+  traits.set_supports_position(true);
+  traits.set_supports_toggle(true);
+  traits.set_is_assumed_state(this->get_assumed_state());
+  return traits;
+}
+
+void FeedbackValve::dump_config() {
+  LOG_VALVE("", "Feedback Valve", this);
+  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->get_open_duration() / 1e3f);
+#ifdef USE_BINARY_SENSOR
+  LOG_BINARY_SENSOR("  ", "Open Endstop", this->get_open_endstop());
+  LOG_BINARY_SENSOR("  ", "Open Feedback", this->get_open_feedback());
+  LOG_BINARY_SENSOR("  ", "Open Obstacle", this->get_open_obstacle());
+#endif
+  ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->get_close_duration() / 1e3f);
+#ifdef USE_BINARY_SENSOR
+  LOG_BINARY_SENSOR("  ", "Close Endstop", this->get_close_endstop());
+  LOG_BINARY_SENSOR("  ", "Close Feedback", this->get_close_feedback());
+  LOG_BINARY_SENSOR("  ", "Close Obstacle", this->get_close_obstacle());
+#endif
+  if (this->get_has_built_in_endstop()) {
+    ESP_LOGCONFIG(TAG, "  Has builtin endstop: YES");
+  }
+  if (this->get_infer_endstop()) {
+    ESP_LOGCONFIG(TAG, "  Infer endstop from movement: YES");
+  }
+  if (this->get_max_duration() < UINT32_MAX) {
+    ESP_LOGCONFIG(TAG, "  Max Duration: %.1fs", this->get_max_duration() / 1e3f);
+  }
+  if (this->get_direction_change_waittime().has_value()) {
+    ESP_LOGCONFIG(TAG, "  Direction change wait time: %.1fs", *this->get_direction_change_waittime() / 1e3f);
+  }
+  if (this->get_acceleration_wait_time()) {
+    ESP_LOGCONFIG(TAG, "  Acceleration wait time: %.1fs", this->get_acceleration_wait_time() / 1e3f);
+  }
+#ifdef USE_BINARY_SENSOR
+  if (this->get_obstacle_rollback() &&
+      (this->get_open_obstacle() != nullptr || this->get_close_obstacle() != nullptr)) {
+    ESP_LOGCONFIG(TAG, "  Obstacle rollback: %.1f%%", this->get_obstacle_rollback() * 100);
+  }
+#endif
+}
+
+}  // namespace esphome::feedback

--- a/esphome/components/feedback/valve/feedback_valve.h
+++ b/esphome/components/feedback/valve/feedback_valve.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../feedback_actuator.h"
+#include "esphome/components/valve/valve.h"
+
+namespace esphome::feedback {
+
+// Inheritance: FeedbackValve -> FeedbackActuatorBase (Component), Valve (ActuatorBase, IActuator)
+// No shared ancestors. No diamond inheritance.
+class FeedbackValve : public FeedbackActuatorBase, public valve::Valve {
+ public:
+  FeedbackValve() { this->set_actuator(this); }
+  valve::ValveTraits get_traits() override;
+  void dump_config() override;
+
+ protected:
+  void control(const valve::ValveCall &call) override { FeedbackActuatorBase::control_(call); }
+};
+
+}  // namespace esphome::feedback

--- a/tests/components/feedback/common.yaml
+++ b/tests/components/feedback/common.yaml
@@ -37,3 +37,29 @@ cover:
       - logger.log: Close Action
     stop_action:
       - logger.log: Stop Action
+
+valve:
+  - platform: feedback
+    name: Feedback Valve
+    id: feedback_valve
+    device_class: water
+    infer_endstop_from_movement: false
+    has_built_in_endstop: false
+    max_duration: 30s
+    direction_change_wait_time: 300ms
+    acceleration_wait_time: 150ms
+    obstacle_rollback: 10%
+    open_duration: 22.1s
+    open_endstop: open_endstop_sensor
+    open_sensor: open_sensor
+    open_obstacle_sensor: open_obstacle_sensor
+    close_duration: 22.4s
+    close_endstop: close_endstop_sensor
+    close_sensor: close_sensor
+    close_obstacle_sensor: close_obstacle_sensor
+    open_action:
+      - logger.log: Valve Open Action
+    close_action:
+      - logger.log: Valve Close Action
+    stop_action:
+      - logger.log: Valve Stop Action

--- a/tests/unit_tests/test_feedback_actuator.py
+++ b/tests/unit_tests/test_feedback_actuator.py
@@ -23,3 +23,15 @@ def test_feedback_actuator_class_exported():
     import esphome.components.feedback as feedback_mod
 
     assert hasattr(feedback_mod, "FeedbackActuatorBase")
+
+
+def test_feedback_valve_inherits_actuator_base():
+    """Verify FeedbackValve inherits FeedbackActuatorBase."""
+    from esphome.components.feedback import FeedbackActuatorBase
+    from esphome.components.feedback.valve import FeedbackValve
+    from esphome.components.valve import Valve
+
+    assert FeedbackValve.inherits_from(FeedbackActuatorBase), (
+        "FeedbackValve does not inherit FeedbackActuatorBase"
+    )
+    assert FeedbackValve.inherits_from(Valve), "FeedbackValve does not inherit Valve"


### PR DESCRIPTION
Adds FeedbackValve, mirroring FeedbackCover but inheriting from valve::Valve. Reuses FeedbackActuatorBase from the parent feedback component for all control / sensor / loop logic. Layout matches the cover platform (feedback/valve/__init__.py + feedback_valve.h/.cpp, AUTO_LOAD = ["feedback"]).

Tests:
  - Unit test verifying FeedbackValve inherits FeedbackActuatorBase + Valve
  - common.yaml extended with a valve entry sharing the same sensors as the cover entry

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
